### PR TITLE
fix: resolve TypeScript build errors in pin-grid and chat-container

### DIFF
--- a/src/components/room/chat/chat-container.tsx
+++ b/src/components/room/chat/chat-container.tsx
@@ -61,7 +61,6 @@ const DmThread = ({
   const { signalingService } = useSignaling();
   const peerMe = usePeerMe();
   const dmChats = useDmChats();
-  const chatActions = useChatActions();
   const [message, setMessage] = useState('');
   const [showPicker, setShowPicker] = useState(false);
   const thread = dmChats[peer.id] ?? [];

--- a/src/components/room/display/pin-grid.tsx
+++ b/src/components/room/display/pin-grid.tsx
@@ -14,7 +14,7 @@ import { useMedia } from '@/hooks/use-media';
 import { PeerTile } from '../grid/peer-tile';
 import MyTile from '../grid/my-tile';
 
-const STRIP_TILE = { width: 160, height: 120 };
+const STRIP_TILE = { width: 160, height: 120, rows: 1, cols: 1, aspectRatio: '4:3' };
 
 const PinnedLarge = ({ peerId }: { peerId: string }) => {
   const videoRef = useRef<HTMLVideoElement>(null);


### PR DESCRIPTION
fix: resolve TypeScript build errors in pin-grid and chat-container

- Add missing Layout fields (rows, cols, aspectRatio) to STRIP_TILE constant
- Remove unused chatActions declaration in DM thread component